### PR TITLE
Don't connect on conststruct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All Notable changes to `dynamark3-client` will be documented in this file
 
+## v2.0.0 - 2016-03-01
+
+### Added
+- Connect method. The client is no longer returned with an active connection upon instantiation
+
+### Changed
+- The static `Dynamark3Client::build` command is now `Dynamark3Client::factory`
+
+### Fixed
+- Nothing
+
+### Deprecated
+- Nothing
+
+### Removed
+- `Dynamark3Client::build`
+
+### Security
+- Nothing
+
+
 ## v1.0.0 - 2016-02-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ All Notable changes to `dynamark3-client` will be documented in this file
 ## v2.0.0 - 2016-03-01
 
 ### Added
-- Connect method. The client is no longer returned with an active connection upon instantiation
+- `connect` method. The client is no longer returned with an active connection upon instantiation
+- `CommandSetxml` Command
 
 ### Changed
 - The static `Dynamark3Client::build` command is now `Dynamark3Client::factory`
+- Not all commands' arguments require quoting. Move this functionality to the `Command` itself
 
 ### Fixed
-- Nothing
+- SETXML command will now work
 
 ### Deprecated
 - Nothing
@@ -21,7 +23,6 @@ All Notable changes to `dynamark3-client` will be documented in this file
 
 ### Security
 - Nothing
-
 
 ## v1.0.0 - 2016-02-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ All Notable changes to `dynamark3-client` will be documented in this file
 ### Added
 - `connect` method. The client is no longer returned with an active connection upon instantiation
 - `CommandSetxml` Command
+- `getArgumentText` test for Commands
 
 ### Changed
 - The static `Dynamark3Client::build` command is now `Dynamark3Client::factory`
-- Not all commands' arguments require quoting. Move this functionality to the `Command` itself
+- Move responsibility of formatting arguments to the `Command` itself
+- Simplified `Dynamark3ClientTest`
 
 ### Fixed
 - SETXML command will now work

--- a/README.md
+++ b/README.md
@@ -21,15 +21,23 @@ $ composer require graze/dynamark3-client
 
 ### Instantiating a client
 
-Use the `build` method to return a `Dynamark3ClientInterface` instance with connection a to `$dsn`:
+Use the `factory` method to return a `Dynamark3ClientInterface` instance:
 
 ``` php
-$dsn = '127.0.0.1:20000';
-$client = Graze\Dynamark3Client\Dynamark3Client::build($dsn);
+$client = Graze\Dynamark3Client\Dynamark3Client::factory();
 ...
 ```
 
 ### Issuing commands
+
+Connect to a remote endpoint using `connect`:
+
+```php
+...
+$dsn = '127.0.0.1:20000';
+$client->connect($dsn);
+...
+```
 
 Commands are then simply method names that can be called directly on the client:
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Command arguments are passed as method paramaters:
 $path = '\hard disk\domino\filecoding\codes.txt';
 $resp = $client->deletefile($path);
 ...
-
 ```
 
 ### Responses

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,6 @@
         }
     ],
     "require": {
-        "graze/telnet-client": "^1.0"
+        "graze/telnet-client": "^2.0"
     }
 }

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -14,10 +14,10 @@
 
 namespace Graze\Dynamark3Client\Command;
 
-use Graze\Dynamark3Client\Command\CommandInterface;
-use Graze\TelnetClient\TelnetResponseInterface;
-use Graze\Dynamark3Client\Dynamark3Response;
-use Graze\Dynamark3Client\Dynamark3Constants;
+use \Graze\Dynamark3Client\Command\CommandInterface;
+use \Graze\TelnetClient\TelnetResponseInterface;
+use \Graze\Dynamark3Client\Dynamark3Response;
+use \Graze\Dynamark3Client\Dynamark3Constants;
 
 abstract class AbstractCommand implements CommandInterface
 {

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -27,6 +27,25 @@ abstract class AbstractCommand implements CommandInterface
     abstract public function getCommandText();
 
     /**
+     * @param array $arguments
+     *
+     * @return string
+     */
+    public function getArgumentText(array $arguments)
+    {
+        if (empty($arguments)) {
+            return '';
+        }
+
+        // add quotes to arguments
+        array_walk($arguments, function (&$value) {
+            $value = sprintf('"%s"', $value);
+        });
+
+        return ' ' . implode(' ', $arguments);
+    }
+
+    /**
      * Default to the TelnetClient's prompt
      *
      * @return string

--- a/src/Command/CommandGetxml.php
+++ b/src/Command/CommandGetxml.php
@@ -14,7 +14,7 @@
 
 namespace Graze\Dynamark3Client\Command;
 
-use Graze\TelnetClient\TelnetResponseInterface;
+use \Graze\TelnetClient\TelnetResponseInterface;
 
 class CommandGetxml extends AbstractCommand
 {

--- a/src/Command/CommandInterface.php
+++ b/src/Command/CommandInterface.php
@@ -24,6 +24,13 @@ interface CommandInterface
     public function getCommandText();
 
     /**
+     * @param array $arguments
+     *
+     * @return string
+     */
+    public function getArgumentText(array $arguments);
+
+    /**
      * @return string
      */
     public function getPrompt();

--- a/src/Command/CommandInterface.php
+++ b/src/Command/CommandInterface.php
@@ -14,7 +14,7 @@
 
 namespace Graze\Dynamark3Client\Command;
 
-use Graze\TelnetClient\TelnetResponseInterface;
+use \Graze\TelnetClient\TelnetResponseInterface;
 
 interface CommandInterface
 {

--- a/src/Command/CommandSetxml.php
+++ b/src/Command/CommandSetxml.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of graze/dynamark3-client.
+ *
+ * Copyright (c) 2016 Nature Delivered Ltd. <https://www.graze.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license https://github.com/graze/dynamark3-client/blob/master/LICENSE.md
+ * @link https://github.com/graze/dynamark3-client
+ */
+
+namespace Graze\Dynamark3Client\Command;
+
+use \Graze\TelnetClient\TelnetResponseInterface;
+
+class CommandSetxml extends AbstractCommand
+{
+    /**
+     * @return string
+     */
+    public function getCommandText()
+    {
+        return 'SETXML';
+    }
+
+    /**
+     * @param array $arguments
+     *
+     * @return string
+     */
+    public function getArgumentText(array $arguments)
+    {
+        if (empty($arguments)) {
+            return '';
+        }
+
+        return ' ' . implode(' ', $arguments);
+    }
+}

--- a/src/CommandResolver.php
+++ b/src/CommandResolver.php
@@ -14,7 +14,7 @@
 
 namespace Graze\Dynamark3Client;
 
-use Graze\Dynamark3Client\Command\CommandGeneric;
+use \Graze\Dynamark3Client\Command\CommandGeneric;
 
 class CommandResolver
 {

--- a/src/Dynamark3Client.php
+++ b/src/Dynamark3Client.php
@@ -43,6 +43,19 @@ class Dynamark3Client
     }
 
     /**
+     * @param string $dsn
+     */
+    public function connect($dsn)
+    {
+        $this->telnet->connect(
+            $dsn,
+            Dynamark3Constants::PROMPT,
+            Dynamark3Constants::PROMPT_ERROR,
+            Dynamark3Constants::LINE_ENDING
+        );
+    }
+
+    /**
      * @param string $name
      * @param array $arguments
      *
@@ -84,21 +97,12 @@ class Dynamark3Client
     }
 
     /**
-     * @param string $dsn
-     *
      * @return Dynamark3Client
      */
-    public static function build($dsn)
+    public static function factory()
     {
-        $telnetClient = TelnetClient::build(
-            $dsn,
-            Dynamark3Constants::PROMPT,
-            Dynamark3Constants::PROMPT_ERROR,
-            Dynamark3Constants::LINE_ENDING
-        );
-
         return new static(
-            $telnetClient,
+            TelnetClient::factory(),
             new CommandResolver()
         );
     }

--- a/src/Dynamark3Client.php
+++ b/src/Dynamark3Client.php
@@ -59,7 +59,7 @@ class Dynamark3Client
      * @param string $name
      * @param array $arguments
      *
-     * @return Graze\Dynamark3Client\Dynamark3Response;
+     * @return Graze\Dynamark3Client\Dynamark3Response
      */
     public function __call($name, array $arguments)
     {

--- a/src/Dynamark3Client.php
+++ b/src/Dynamark3Client.php
@@ -14,11 +14,11 @@
 
 namespace Graze\Dynamark3Client;
 
-use Graze\TelnetClient\TelnetClientInterface;
-use Graze\Dynamark3Client\CommandResolver;
-use Graze\Dynamark3Client\Command\CommandInterface;
-use Graze\TelnetClient\TelnetClient;
-use Graze\Dynamark3Client\Dynamark3Constants;
+use \Graze\TelnetClient\TelnetClientInterface;
+use \Graze\Dynamark3Client\CommandResolver;
+use \Graze\Dynamark3Client\Command\CommandInterface;
+use \Graze\TelnetClient\TelnetClient;
+use \Graze\Dynamark3Client\Dynamark3Constants;
 
 class Dynamark3Client
 {

--- a/src/Dynamark3Client.php
+++ b/src/Dynamark3Client.php
@@ -64,32 +64,8 @@ class Dynamark3Client
     public function __call($name, array $arguments)
     {
         $command = $this->commandResolver->resolve($name);
-        array_unshift($arguments, $command);
-        return call_user_func_array([$this, 'send'], $arguments);
-    }
-
-    /**
-     * @param CommandInterface $command
-     *
-     * @return Graze\Dynamark3Client\Dynamark3Response;
-     */
-    protected function send(CommandInterface $command)
-    {
-        $arguments =  func_get_args();
-        $command = array_shift($arguments);
-
-        $argumentsString = '';
-        if ($arguments) {
-            // add quotes to arguments
-            array_walk($arguments, function (&$value) {
-                $value = sprintf('"%s"', $value);
-            });
-
-            $argumentsString = ' ' . implode(' ', $arguments);
-        }
-
         $telnetResponse = $this->telnet->execute(
-            $command->getCommandText() . $argumentsString,
+            $command->getCommandText() . $command->getArgumentText($arguments),
             $command->getPrompt()
         );
 

--- a/tests/functional/CommandResolverTest.php
+++ b/tests/functional/CommandResolverTest.php
@@ -14,9 +14,9 @@
 
 namespace Graze\Dynamark3Client\Test\Functional;
 
-use Graze\Dynamark3Client\CommandResolver;
-use Graze\Dynamark3Client\Command\CommandGeneric;
-use Graze\Dynamark3Client\Command\CommandGetxml;
+use \Graze\Dynamark3Client\CommandResolver;
+use \Graze\Dynamark3Client\Command\CommandGeneric;
+use \Graze\Dynamark3Client\Command\CommandGetxml;
 
 class Dynamark3ResolverTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/src/AbstractCommandTestCase.php
+++ b/tests/src/AbstractCommandTestCase.php
@@ -44,9 +44,16 @@ abstract class AbstractCommandTestCase extends \PHPUnit_Framework_TestCase
     abstract protected function getExpectedResponseText();
 
     /**
+     * The expected result if $command->getArgumentText(['a', '1']) was called.
+     *
+     * @return string
+     */
+    abstract protected function getExpectedArgumentText();
+
+    /**
      * @return void
      */
-    public function testCommandSuccess()
+    public function testParseResponseSuccess()
     {
         $command = $this->getCommand();
 
@@ -66,7 +73,7 @@ abstract class AbstractCommandTestCase extends \PHPUnit_Framework_TestCase
     /**
      * @return void
      */
-    public function testCommandError()
+    public function testParseResponseError()
     {
         $command = $this->getCommand();
 
@@ -79,6 +86,12 @@ abstract class AbstractCommandTestCase extends \PHPUnit_Framework_TestCase
         $response = $command->parseResponse($telnetResponse);
         $this->assertTrue($response->isError());
         $this->assertEquals(6, $response->getErrorCode());
+    }
+
+    public function testGetArgumentText()
+    {
+        $command = $this->getCommand();
+        $this->assertEquals($this->getExpectedArgumentText(), $command->getArgumentText(['a', '1']));
     }
 
     /**

--- a/tests/src/AbstractCommandTestCase.php
+++ b/tests/src/AbstractCommandTestCase.php
@@ -14,11 +14,11 @@
 
 namespace Graze\Dynamark3Client\Test;
 
-use Graze\TelnetClient\PromptMatcher;
-use Graze\TelnetClient\TelnetResponseInterface;
-use Graze\Dynamark3Client\Dynamark3Constants;
-use Graze\Dynamark3Client\Command\CommandInterface;
-use Mockery as m;
+use \Graze\TelnetClient\PromptMatcher;
+use \Graze\TelnetClient\TelnetResponseInterface;
+use \Graze\Dynamark3Client\Dynamark3Constants;
+use \Graze\Dynamark3Client\Command\CommandInterface;
+use \Mockery as m;
 
 abstract class AbstractCommandTestCase extends \PHPUnit_Framework_TestCase
 {

--- a/tests/unit/Command/CommandGenericTest.php
+++ b/tests/unit/Command/CommandGenericTest.php
@@ -14,9 +14,9 @@
 
 namespace Graze\Dynamark3Client\Test\Unit\Command;
 
-use Graze\Dynamark3Client\Test\AbstractCommandTestCase;
-use Graze\Dynamark3Client\Dynamark3Constants;
-use Graze\Dynamark3Client\Command\CommandGeneric;
+use \Graze\Dynamark3Client\Test\AbstractCommandTestCase;
+use \Graze\Dynamark3Client\Dynamark3Constants;
+use \Graze\Dynamark3Client\Command\CommandGeneric;
 
 class CommandGenericTest extends AbstractCommandTestCase
 {

--- a/tests/unit/Command/CommandGenericTest.php
+++ b/tests/unit/Command/CommandGenericTest.php
@@ -48,4 +48,12 @@ class CommandGenericTest extends AbstractCommandTestCase
     {
         return Dynamark3Constants::PROMPT;
     }
+
+    /**
+     * @return string
+     */
+    protected function getExpectedArgumentText()
+    {
+        return ' "a" "1"';
+    }
 }

--- a/tests/unit/Command/CommandGetXmlTest.php
+++ b/tests/unit/Command/CommandGetXmlTest.php
@@ -14,9 +14,9 @@
 
 namespace Graze\Dynamark3Client\Test\Unit\Command;
 
-use Graze\Dynamark3Client\Test\AbstractCommandTestCase;
-use Graze\Dynamark3Client\Command\CommandGetxml;
-use Graze\Dynamark3Client\Dynamark3Constants;
+use \Graze\Dynamark3Client\Test\AbstractCommandTestCase;
+use \Graze\Dynamark3Client\Command\CommandGetxml;
+use \Graze\Dynamark3Client\Dynamark3Constants;
 
 class CommandGetxmlTest extends AbstractCommandTestCase
 {

--- a/tests/unit/Command/CommandSetxmlTest.php
+++ b/tests/unit/Command/CommandSetxmlTest.php
@@ -15,17 +15,17 @@
 namespace Graze\Dynamark3Client\Test\Unit\Command;
 
 use \Graze\Dynamark3Client\Test\AbstractCommandTestCase;
-use \Graze\Dynamark3Client\Command\CommandGetxml;
+use \Graze\Dynamark3Client\Command\CommandSetxml;
 use \Graze\Dynamark3Client\Dynamark3Constants;
 
-class CommandGetxmlTest extends AbstractCommandTestCase
+class CommandSetxmlTest extends AbstractCommandTestCase
 {
     /**
      * @return CommandGetxml
      */
     protected function getCommand()
     {
-        return new CommandGetxml();
+        return new CommandSetxml();
     }
 
     /**
@@ -33,7 +33,7 @@ class CommandGetxmlTest extends AbstractCommandTestCase
      */
     protected function getRawTelnetResponse()
     {
-        return 'RESULT GETXML <xml><node>cool xml</node></xml>' . Dynamark3Constants::LINE_ENDING;
+        return Dynamark3Constants::PROMPT . Dynamark3Constants::LINE_ENDING;
     }
 
     /**
@@ -41,7 +41,7 @@ class CommandGetxmlTest extends AbstractCommandTestCase
      */
     protected function getExpectedResponseText()
     {
-        return '<xml><node>cool xml</node></xml>';
+        return Dynamark3Constants::PROMPT;
     }
 
     /**
@@ -49,6 +49,6 @@ class CommandGetxmlTest extends AbstractCommandTestCase
      */
     protected function getExpectedArgumentText()
     {
-        return ' "a" "1"';
+        return ' a 1';
     }
 }

--- a/tests/unit/Dynamark3ClientTest.php
+++ b/tests/unit/Dynamark3ClientTest.php
@@ -25,13 +25,6 @@ use \Mockery as m;
 
 class Dynamark3ClientTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @param string $expectedCommand
-     * @param string $commandText
-     * @param array $args
-     *
-     * @return void
-     */
     public function testSend()
     {
         $telnetResponse = m::mock(TelnetResponseInterface::class);

--- a/tests/unit/Dynamark3ClientTest.php
+++ b/tests/unit/Dynamark3ClientTest.php
@@ -14,13 +14,13 @@
 
 namespace Graze\Dynamark3Client\Test\Unit;
 
-use Graze\TelnetClient\TelnetResponseInterface;
-use Graze\Dynamark3Client\Command\CommandInterface;
-use Graze\TelnetClient\TelnetClientInterface;
-use Graze\Dynamark3Client\CommandResolver;
-use Graze\Dynamark3Client\Dynamark3Client;
-use Graze\Dynamark3Client\Dynamark3Constants;
-use Mockery as m;
+use \Graze\TelnetClient\TelnetResponseInterface;
+use \Graze\Dynamark3Client\Command\CommandInterface;
+use \Graze\TelnetClient\TelnetClientInterface;
+use \Graze\Dynamark3Client\CommandResolver;
+use \Graze\Dynamark3Client\Dynamark3Client;
+use \Graze\Dynamark3Client\Dynamark3Constants;
+use \Mockery as m;
 
 class Dynamark3ClientTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/unit/Dynamark3ClientTest.php
+++ b/tests/unit/Dynamark3ClientTest.php
@@ -19,6 +19,7 @@ use Graze\Dynamark3Client\Command\CommandInterface;
 use Graze\TelnetClient\TelnetClientInterface;
 use Graze\Dynamark3Client\CommandResolver;
 use Graze\Dynamark3Client\Dynamark3Client;
+use Graze\Dynamark3Client\Dynamark3Constants;
 use Mockery as m;
 
 class Dynamark3ClientTest extends \PHPUnit_Framework_TestCase
@@ -72,5 +73,30 @@ class Dynamark3ClientTest extends \PHPUnit_Framework_TestCase
             ['aCommandYeah "arg1" "arg2"', 'aCommandYeah', ['arg1', 'arg2']],
             ['sweetCommandBro', 'sweetCommandBro', []],
         ];
+    }
+
+    public function testFactory()
+    {
+        $this->assertInstanceOf(Dynamark3Client::class, Dynamark3Client::factory());
+    }
+
+    public function testConnect()
+    {
+        $dsn = '127.0.0.1:23';
+        $telnet = m::mock(TelnetClientInterface::class)
+            ->shouldReceive('connect')
+            ->with(
+                $dsn,
+                Dynamark3Constants::PROMPT,
+                Dynamark3Constants::PROMPT_ERROR,
+                Dynamark3Constants::LINE_ENDING
+            )
+            ->once()
+            ->getMock();
+
+        $commandResolver = m::mock(CommandResolver::class);
+
+        $client = new Dynamark3Client($telnet, $commandResolver);
+        $client->connect($dsn);
     }
 }

--- a/tests/unit/Dynamark3ClientTest.php
+++ b/tests/unit/Dynamark3ClientTest.php
@@ -19,60 +19,55 @@ use \Graze\Dynamark3Client\Command\CommandInterface;
 use \Graze\TelnetClient\TelnetClientInterface;
 use \Graze\Dynamark3Client\CommandResolver;
 use \Graze\Dynamark3Client\Dynamark3Client;
+use \Graze\Dynamark3Client\Dynamark3ResponseInterface;
 use \Graze\Dynamark3Client\Dynamark3Constants;
 use \Mockery as m;
 
 class Dynamark3ClientTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @dataProvider dataProviderSend
-     *
      * @param string $expectedCommand
      * @param string $commandText
      * @param array $args
      *
      * @return void
      */
-    public function testSend($expectedCommand, $commandText, array $args)
+    public function testSend()
     {
         $telnetResponse = m::mock(TelnetResponseInterface::class);
         $telnet = m::mock(TelnetClientInterface::class)
             ->shouldReceive('execute')
-            ->with($expectedCommand, null)
+            ->with('COMMAND ARGS', null)
             ->andReturn($telnetResponse)
             ->once()
             ->getMock();
 
+        $dynamark3Response = m::mock(Dynamark3ResponseInterface::class);
         $command = m::mock(CommandInterface::class)
             ->shouldReceive('getCommandText')
-            ->andReturn($commandText)
+            ->andReturn('COMMAND')
+            ->once()
+            ->shouldReceive('getArgumentText')
+            ->andReturn(' ARGS')
             ->once()
             ->shouldReceive('getPrompt')
             ->andReturn(null)
             ->once()
             ->shouldReceive('parseResponse')
             ->with($telnetResponse)
+            ->andReturn($dynamark3Response)
             ->once()
             ->getMock();
         $commandResolver = m::mock(CommandResolver::class)
             ->shouldReceive('resolve')
-            ->with($commandText)
+            ->with('command')
             ->andReturn($command)
+            ->once()
             ->getMock();
 
         $client = new Dynamark3Client($telnet, $commandResolver);
-        call_user_func_array([$client, $commandText], $args);
-    }
-
-    /**
-     * @return []
-     */
-    public function dataProviderSend()
-    {
-        return [
-            ['aCommandYeah "arg1" "arg2"', 'aCommandYeah', ['arg1', 'arg2']],
-            ['sweetCommandBro', 'sweetCommandBro', []],
-        ];
+        $resp = $client->command();
+        $this->assertSame($dynamark3Response, $resp);
     }
 
     public function testFactory()

--- a/tests/unit/Dynamark3ResponseTest.php
+++ b/tests/unit/Dynamark3ResponseTest.php
@@ -14,7 +14,7 @@
 
 namespace Graze\Dynamark3Client\Test\Unit;
 
-use Graze\Dynamark3Client\Dynamark3Response;
+use \Graze\Dynamark3Client\Dynamark3Response;
 
 class Dynamark3ResponseTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Don't connect on `__construct` but provide a `connect` method. This allows the client to be injected as a dependency without requiring the dsn to be known ahead of time.

``` php
// previous usage
class MyClass
{
    public function __construct(Dynamark3Client $client)
    {
        ...
    }

    public function doSomething()
    {
        // do something with client that is already connected to $dsn ($dsn required ahead of time of use)
        ...
    }
}

// new usage
class MyClass
{
    public function __construct(Dynamark3Client $client)
    {
        ...
    }

    public function doSomething($dsn)
    {
        // connect to dsn of choice
        $this->client->connect($dsn);
        // do something with client
        ...
    }
}
```
