### PR TITLE
Not all command arguments need quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All Notable changes to `dynamark3-client` will be documented in this file
 
+## v2.0.0 - 2016-03-01
+
+### Added
+- Connect method. The client is no longer returned with an active connection upon instantiation
+
+### Changed
+- The static `Dynamark3Client::build` command is now `Dynamark3Client::factory`
+
+### Fixed
+- Nothing
+
+### Deprecated
+- Nothing
+
+### Removed
+- `Dynamark3Client::build`
+
+### Security
+- Nothing
+
+
 ## v1.0.0 - 2016-02-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ All Notable changes to `dynamark3-client` will be documented in this file
 ## v2.0.0 - 2016-03-01
 
 ### Added
-- Connect method. The client is no longer returned with an active connection upon instantiation
+- `connect` method. The client is no longer returned with an active connection upon instantiation
+- `CommandSetxml` Command
 
 ### Changed
 - The static `Dynamark3Client::build` command is now `Dynamark3Client::factory`
+- Not all commands' arguments require quoting. Move this functionality to the `Command` itself
 
 ### Fixed
-- Nothing
+- SETXML command will now work
 
 ### Deprecated
 - Nothing
@@ -21,7 +23,6 @@ All Notable changes to `dynamark3-client` will be documented in this file
 
 ### Security
 - Nothing
-
 
 ## v1.0.0 - 2016-02-17
 

--- a/README.md
+++ b/README.md
@@ -21,15 +21,23 @@ $ composer require graze/dynamark3-client
 
 ### Instantiating a client
 
-Use the `build` method to return a `Dynamark3ClientInterface` instance with connection a to `$dsn`:
+Use the `factory` method to return a `Dynamark3ClientInterface` instance:
 
 ``` php
-$dsn = '127.0.0.1:20000';
-$client = Graze\Dynamark3Client\Dynamark3Client::build($dsn);
+$client = Graze\Dynamark3Client\Dynamark3Client::factory();
 ...
 ```
 
 ### Issuing commands
+
+Connect to a remote endpoint using `connect`:
+
+```php
+...
+$dsn = '127.0.0.1:20000';
+$client->connect($dsn);
+...
+```
 
 Commands are then simply method names that can be called directly on the client:
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Command arguments are passed as method paramaters:
 $path = '\hard disk\domino\filecoding\codes.txt';
 $resp = $client->deletefile($path);
 ...
-
 ```
 
 ### Responses

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,6 @@
         }
     ],
     "require": {
-        "graze/telnet-client": "^1.0"
+        "graze/telnet-client": "^2.0"
     }
 }

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -14,10 +14,10 @@
 
 namespace Graze\Dynamark3Client\Command;
 
-use Graze\Dynamark3Client\Command\CommandInterface;
-use Graze\TelnetClient\TelnetResponseInterface;
-use Graze\Dynamark3Client\Dynamark3Response;
-use Graze\Dynamark3Client\Dynamark3Constants;
+use \Graze\Dynamark3Client\Command\CommandInterface;
+use \Graze\TelnetClient\TelnetResponseInterface;
+use \Graze\Dynamark3Client\Dynamark3Response;
+use \Graze\Dynamark3Client\Dynamark3Constants;
 
 abstract class AbstractCommand implements CommandInterface
 {

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -27,6 +27,25 @@ abstract class AbstractCommand implements CommandInterface
     abstract public function getCommandText();
 
     /**
+     * @param array $arguments
+     *
+     * @return string
+     */
+    public function getArgumentText(array $arguments)
+    {
+        if (empty($arguments)) {
+            return '';
+        }
+
+        // add quotes to arguments
+        array_walk($arguments, function (&$value) {
+            $value = sprintf('"%s"', $value);
+        });
+
+        return ' ' . implode(' ', $arguments);
+    }
+
+    /**
      * Default to the TelnetClient's prompt
      *
      * @return string

--- a/src/Command/CommandGetxml.php
+++ b/src/Command/CommandGetxml.php
@@ -14,7 +14,7 @@
 
 namespace Graze\Dynamark3Client\Command;
 
-use Graze\TelnetClient\TelnetResponseInterface;
+use \Graze\TelnetClient\TelnetResponseInterface;
 
 class CommandGetxml extends AbstractCommand
 {

--- a/src/Command/CommandInterface.php
+++ b/src/Command/CommandInterface.php
@@ -24,6 +24,13 @@ interface CommandInterface
     public function getCommandText();
 
     /**
+     * @param array $arguments
+     *
+     * @return string
+     */
+    public function getArgumentText(array $arguments);
+
+    /**
      * @return string
      */
     public function getPrompt();

--- a/src/Command/CommandInterface.php
+++ b/src/Command/CommandInterface.php
@@ -14,7 +14,7 @@
 
 namespace Graze\Dynamark3Client\Command;
 
-use Graze\TelnetClient\TelnetResponseInterface;
+use \Graze\TelnetClient\TelnetResponseInterface;
 
 interface CommandInterface
 {

--- a/src/Command/CommandSetxml.php
+++ b/src/Command/CommandSetxml.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of graze/dynamark3-client.
+ *
+ * Copyright (c) 2016 Nature Delivered Ltd. <https://www.graze.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license https://github.com/graze/dynamark3-client/blob/master/LICENSE.md
+ * @link https://github.com/graze/dynamark3-client
+ */
+
+namespace Graze\Dynamark3Client\Command;
+
+use \Graze\TelnetClient\TelnetResponseInterface;
+
+class CommandSetxml extends AbstractCommand
+{
+    /**
+     * @return string
+     */
+    public function getCommandText()
+    {
+        return 'SETXML';
+    }
+
+    /**
+     * @param array $arguments
+     *
+     * @return string
+     */
+    public function getArgumentText(array $arguments)
+    {
+        if (empty($arguments)) {
+            return '';
+        }
+
+        return ' ' . implode(' ', $arguments);
+    }
+}

--- a/src/CommandResolver.php
+++ b/src/CommandResolver.php
@@ -14,7 +14,7 @@
 
 namespace Graze\Dynamark3Client;
 
-use Graze\Dynamark3Client\Command\CommandGeneric;
+use \Graze\Dynamark3Client\Command\CommandGeneric;
 
 class CommandResolver
 {

--- a/src/Dynamark3Client.php
+++ b/src/Dynamark3Client.php
@@ -43,6 +43,19 @@ class Dynamark3Client
     }
 
     /**
+     * @param string $dsn
+     */
+    public function connect($dsn)
+    {
+        $this->telnet->connect(
+            $dsn,
+            Dynamark3Constants::PROMPT,
+            Dynamark3Constants::PROMPT_ERROR,
+            Dynamark3Constants::LINE_ENDING
+        );
+    }
+
+    /**
      * @param string $name
      * @param array $arguments
      *
@@ -84,21 +97,12 @@ class Dynamark3Client
     }
 
     /**
-     * @param string $dsn
-     *
      * @return Dynamark3Client
      */
-    public static function build($dsn)
+    public static function factory()
     {
-        $telnetClient = TelnetClient::build(
-            $dsn,
-            Dynamark3Constants::PROMPT,
-            Dynamark3Constants::PROMPT_ERROR,
-            Dynamark3Constants::LINE_ENDING
-        );
-
         return new static(
-            $telnetClient,
+            TelnetClient::factory(),
             new CommandResolver()
         );
     }

--- a/src/Dynamark3Client.php
+++ b/src/Dynamark3Client.php
@@ -14,11 +14,11 @@
 
 namespace Graze\Dynamark3Client;
 
-use Graze\TelnetClient\TelnetClientInterface;
-use Graze\Dynamark3Client\CommandResolver;
-use Graze\Dynamark3Client\Command\CommandInterface;
-use Graze\TelnetClient\TelnetClient;
-use Graze\Dynamark3Client\Dynamark3Constants;
+use \Graze\TelnetClient\TelnetClientInterface;
+use \Graze\Dynamark3Client\CommandResolver;
+use \Graze\Dynamark3Client\Command\CommandInterface;
+use \Graze\TelnetClient\TelnetClient;
+use \Graze\Dynamark3Client\Dynamark3Constants;
 
 class Dynamark3Client
 {

--- a/src/Dynamark3Client.php
+++ b/src/Dynamark3Client.php
@@ -64,32 +64,8 @@ class Dynamark3Client
     public function __call($name, array $arguments)
     {
         $command = $this->commandResolver->resolve($name);
-        array_unshift($arguments, $command);
-        return call_user_func_array([$this, 'send'], $arguments);
-    }
-
-    /**
-     * @param CommandInterface $command
-     *
-     * @return Graze\Dynamark3Client\Dynamark3Response;
-     */
-    protected function send(CommandInterface $command)
-    {
-        $arguments =  func_get_args();
-        $command = array_shift($arguments);
-
-        $argumentsString = '';
-        if ($arguments) {
-            // add quotes to arguments
-            array_walk($arguments, function (&$value) {
-                $value = sprintf('"%s"', $value);
-            });
-
-            $argumentsString = ' ' . implode(' ', $arguments);
-        }
-
         $telnetResponse = $this->telnet->execute(
-            $command->getCommandText() . $argumentsString,
+            $command->getCommandText() . $command->getArgumentText($arguments),
             $command->getPrompt()
         );
 

--- a/tests/functional/CommandResolverTest.php
+++ b/tests/functional/CommandResolverTest.php
@@ -14,9 +14,9 @@
 
 namespace Graze\Dynamark3Client\Test\Functional;
 
-use Graze\Dynamark3Client\CommandResolver;
-use Graze\Dynamark3Client\Command\CommandGeneric;
-use Graze\Dynamark3Client\Command\CommandGetxml;
+use \Graze\Dynamark3Client\CommandResolver;
+use \Graze\Dynamark3Client\Command\CommandGeneric;
+use \Graze\Dynamark3Client\Command\CommandGetxml;
 
 class Dynamark3ResolverTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/src/AbstractCommandTestCase.php
+++ b/tests/src/AbstractCommandTestCase.php
@@ -14,11 +14,11 @@
 
 namespace Graze\Dynamark3Client\Test;
 
-use Graze\TelnetClient\PromptMatcher;
-use Graze\TelnetClient\TelnetResponseInterface;
-use Graze\Dynamark3Client\Dynamark3Constants;
-use Graze\Dynamark3Client\Command\CommandInterface;
-use Mockery as m;
+use \Graze\TelnetClient\PromptMatcher;
+use \Graze\TelnetClient\TelnetResponseInterface;
+use \Graze\Dynamark3Client\Dynamark3Constants;
+use \Graze\Dynamark3Client\Command\CommandInterface;
+use \Mockery as m;
 
 abstract class AbstractCommandTestCase extends \PHPUnit_Framework_TestCase
 {

--- a/tests/unit/Command/CommandGenericTest.php
+++ b/tests/unit/Command/CommandGenericTest.php
@@ -14,9 +14,9 @@
 
 namespace Graze\Dynamark3Client\Test\Unit\Command;
 
-use Graze\Dynamark3Client\Test\AbstractCommandTestCase;
-use Graze\Dynamark3Client\Dynamark3Constants;
-use Graze\Dynamark3Client\Command\CommandGeneric;
+use \Graze\Dynamark3Client\Test\AbstractCommandTestCase;
+use \Graze\Dynamark3Client\Dynamark3Constants;
+use \Graze\Dynamark3Client\Command\CommandGeneric;
 
 class CommandGenericTest extends AbstractCommandTestCase
 {

--- a/tests/unit/Command/CommandGetXmlTest.php
+++ b/tests/unit/Command/CommandGetXmlTest.php
@@ -14,9 +14,9 @@
 
 namespace Graze\Dynamark3Client\Test\Unit\Command;
 
-use Graze\Dynamark3Client\Test\AbstractCommandTestCase;
-use Graze\Dynamark3Client\Command\CommandGetxml;
-use Graze\Dynamark3Client\Dynamark3Constants;
+use \Graze\Dynamark3Client\Test\AbstractCommandTestCase;
+use \Graze\Dynamark3Client\Command\CommandGetxml;
+use \Graze\Dynamark3Client\Dynamark3Constants;
 
 class CommandGetxmlTest extends AbstractCommandTestCase
 {

--- a/tests/unit/Dynamark3ClientTest.php
+++ b/tests/unit/Dynamark3ClientTest.php
@@ -14,13 +14,13 @@
 
 namespace Graze\Dynamark3Client\Test\Unit;
 
-use Graze\TelnetClient\TelnetResponseInterface;
-use Graze\Dynamark3Client\Command\CommandInterface;
-use Graze\TelnetClient\TelnetClientInterface;
-use Graze\Dynamark3Client\CommandResolver;
-use Graze\Dynamark3Client\Dynamark3Client;
-use Graze\Dynamark3Client\Dynamark3Constants;
-use Mockery as m;
+use \Graze\TelnetClient\TelnetResponseInterface;
+use \Graze\Dynamark3Client\Command\CommandInterface;
+use \Graze\TelnetClient\TelnetClientInterface;
+use \Graze\Dynamark3Client\CommandResolver;
+use \Graze\Dynamark3Client\Dynamark3Client;
+use \Graze\Dynamark3Client\Dynamark3Constants;
+use \Mockery as m;
 
 class Dynamark3ClientTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/unit/Dynamark3ClientTest.php
+++ b/tests/unit/Dynamark3ClientTest.php
@@ -19,6 +19,7 @@ use Graze\Dynamark3Client\Command\CommandInterface;
 use Graze\TelnetClient\TelnetClientInterface;
 use Graze\Dynamark3Client\CommandResolver;
 use Graze\Dynamark3Client\Dynamark3Client;
+use Graze\Dynamark3Client\Dynamark3Constants;
 use Mockery as m;
 
 class Dynamark3ClientTest extends \PHPUnit_Framework_TestCase
@@ -72,5 +73,30 @@ class Dynamark3ClientTest extends \PHPUnit_Framework_TestCase
             ['aCommandYeah "arg1" "arg2"', 'aCommandYeah', ['arg1', 'arg2']],
             ['sweetCommandBro', 'sweetCommandBro', []],
         ];
+    }
+
+    public function testFactory()
+    {
+        $this->assertInstanceOf(Dynamark3Client::class, Dynamark3Client::factory());
+    }
+
+    public function testConnect()
+    {
+        $dsn = '127.0.0.1:23';
+        $telnet = m::mock(TelnetClientInterface::class)
+            ->shouldReceive('connect')
+            ->with(
+                $dsn,
+                Dynamark3Constants::PROMPT,
+                Dynamark3Constants::PROMPT_ERROR,
+                Dynamark3Constants::LINE_ENDING
+            )
+            ->once()
+            ->getMock();
+
+        $commandResolver = m::mock(CommandResolver::class);
+
+        $client = new Dynamark3Client($telnet, $commandResolver);
+        $client->connect($dsn);
     }
 }

--- a/tests/unit/Dynamark3ResponseTest.php
+++ b/tests/unit/Dynamark3ResponseTest.php
@@ -14,7 +14,7 @@
 
 namespace Graze\Dynamark3Client\Test\Unit;
 
-use Graze\Dynamark3Client\Dynamark3Response;
+use \Graze\Dynamark3Client\Dynamark3Response;
 
 class Dynamark3ResponseTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Move the responsibility of formatting command arguments to the `Command*` class itself.
