### PR TITLE
Add client interface

### DIFF
--- a/src/Dynamark3Client.php
+++ b/src/Dynamark3Client.php
@@ -20,7 +20,7 @@ use \Graze\Dynamark3Client\Command\CommandInterface;
 use \Graze\TelnetClient\TelnetClient;
 use \Graze\Dynamark3Client\Dynamark3Constants;
 
-class Dynamark3Client
+class Dynamark3Client implements Dynamark3ClientInterface
 {
     /**
      * @var TelnetClientInterface
@@ -59,7 +59,7 @@ class Dynamark3Client
      * @param string $name
      * @param array  $arguments
      *
-     * @return Graze\Dynamark3Client\Dynamark3Response
+     * @return Dynamark3ResponseInterface
      */
     public function __call($name, array $arguments)
     {

--- a/src/Dynamark3ClientInterface.php
+++ b/src/Dynamark3ClientInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of graze/dynamark3-client.
+ *
+ * Copyright (c) 2016 Nature Delivered Ltd. <https://www.graze.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license https://github.com/graze/dynamark3-client/blob/master/LICENSE.md
+ * @link    https://github.com/graze/dynamark3-client
+ */
+
+namespace Graze\Dynamark3Client;
+
+interface Dynamark3ClientInterface
+{
+    /**
+     * @param string $dsn
+     */
+    public function connect($dsn);
+
+    /**
+     * @param string $name
+     * @param array  $arguments
+     *
+     * @return Dynamark3ResponseInterface
+     */
+    public function __call($name, array $arguments);
+}


### PR DESCRIPTION
Adds an interface to the `Dynamark3Client` so new clients can be added without having to inherit it.